### PR TITLE
Feature/custom serialization 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 vantage6_toolkit.egg-info/
 
 vantage6/tools/__pycache__/
+.eggs/
+.idea/
+venv/

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     ],
     extras_require={
     },
+    tests_require=['pytest'],
     package_data={
         'vantage6.tools': [
             'VERSION'

--- a/tests/algorithm_module.py
+++ b/tests/algorithm_module.py
@@ -1,0 +1,5 @@
+import pandas as pd
+
+
+def RPC_hello_world(data: pd.DataFrame):
+    return data

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1,0 +1,29 @@
+import pickle
+from pathlib import Path
+from vantage6.tools import deserialization
+
+SIMPLE_TARGET_DATA = {'key': 'value'}
+
+
+def test_deserialize_json(tmp_path: Path):
+    data = '{"key": "value"}'
+    json_path = tmp_path / 'jsonfile.json'
+    json_path.write_text(data)
+
+    with json_path.open('r') as f:
+        result = deserialization.deserialize(f, 'json')
+
+        assert SIMPLE_TARGET_DATA == result
+
+
+def test_deserialize_pickle(tmp_path: Path):
+    data = {'key': 'value'}
+
+    pickle_path = tmp_path / 'picklefile.pkl'
+
+    with pickle_path.open('wb') as f:
+        pickle.dump(data, f)
+
+    with pickle_path.open('rb') as f:
+        result = deserialization.deserialize(f, 'pickle')
+        assert SIMPLE_TARGET_DATA == result

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pandas as pd
 
 from vantage6.tools import docker_wrapper
+import pytest
 
 MODULE_NAME = 'algorithm_module'
 DATA = 'column1,column2\n1,2'
@@ -11,14 +12,19 @@ TOKEN = 'This is a fake token'
 INPUT_PARAMETERS = {'method': 'hello_world'}
 
 
-def test_docker_wrapper(tmp_path):
-    input_file = tmp_path / 'input_file.pkl'
-    db_file = tmp_path / 'db_file.csv'
-    token_file = tmp_path / 'token.txt'
-    output_file = tmp_path / 'output_file.pkl'
+def test_old_pickle_input_wrapper(tmp_path):
+    input_file = tmp_path / 'input.pkl'
 
     with input_file.open('wb') as f:
         pickle.dump(INPUT_PARAMETERS, f)
+
+    run_docker_wrapper(tmp_path, input_file)
+
+
+def run_docker_wrapper(tmp_path, input_file):
+    db_file = tmp_path / 'db_file.csv'
+    token_file = tmp_path / 'token.txt'
+    output_file = tmp_path / 'output_file.pkl'
 
     db_file.write_text(DATA)
     token_file.write_text(TOKEN)

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -1,0 +1,47 @@
+import pickle
+from unittest.mock import patch
+
+import pandas as pd
+
+from vantage6.tools import docker_wrapper
+
+MODULE_NAME = 'algorithm_module'
+DATA = 'column1,column2\n1,2'
+TOKEN = 'This is a fake token'
+INPUT_PARAMETERS = {'method': 'hello_world'}
+
+
+def test_docker_wrapper(tmp_path):
+    input_file = tmp_path / 'input_file.pkl'
+    db_file = tmp_path / 'db_file.csv'
+    token_file = tmp_path / 'token.txt'
+    output_file = tmp_path / 'output_file.pkl'
+
+    with input_file.open('wb') as f:
+        pickle.dump(INPUT_PARAMETERS, f)
+
+    db_file.write_text(DATA)
+    token_file.write_text(TOKEN)
+
+    with patch('vantage6.tools.docker_wrapper.os') as mock_os:
+        mock_os.environ = {
+            'INPUT_FILE': input_file,
+            'TOKEN_FILE': token_file,
+            'OUTPUT_FILE': output_file,
+            'DATABASE_URI': db_file
+        }
+
+        docker_wrapper.docker_wrapper(MODULE_NAME)
+
+    with output_file.open('rb') as f:
+        result = pickle.load(f)
+
+        print(result)
+
+        target = pd.DataFrame([[1, 2]], columns=['column1', 'column2'])
+        pd.testing.assert_frame_equal(target, result)
+
+
+def _prepare_input(input_, input_file):
+    input_file.write(input_.encode())
+    input_file.seek(0)

--- a/tests/test_docker_wrapper.py
+++ b/tests/test_docker_wrapper.py
@@ -1,15 +1,19 @@
+import json
 import pickle
 from unittest.mock import patch
 
 import pandas as pd
+from pytest import raises
 
 from vantage6.tools import docker_wrapper
-import pytest
+from vantage6.tools.exceptions import DeserializationException
 
 MODULE_NAME = 'algorithm_module'
 DATA = 'column1,column2\n1,2'
 TOKEN = 'This is a fake token'
 INPUT_PARAMETERS = {'method': 'hello_world'}
+JSON = 'json'
+SEPARATOR = '.'
 
 
 def test_old_pickle_input_wrapper(tmp_path):
@@ -17,6 +21,26 @@ def test_old_pickle_input_wrapper(tmp_path):
 
     with input_file.open('wb') as f:
         pickle.dump(INPUT_PARAMETERS, f)
+
+    run_docker_wrapper(tmp_path, input_file)
+
+
+def test_json_input_without_format_raises_deserializationexception(tmp_path):
+    input_file = tmp_path / 'input.json'
+
+    with input_file.open('wb') as f:
+        f.write(json.dumps(INPUT_PARAMETERS).encode())
+
+    with raises(DeserializationException):
+        run_docker_wrapper(tmp_path, input_file)
+
+
+def test_json_input_with_format_succeeds(tmp_path):
+    input_file = tmp_path / 'input.txt'
+
+    with input_file.open('wb') as f:
+        f.write(f'JSON{SEPARATOR}'.encode())
+        f.write(json.dumps(INPUT_PARAMETERS).encode())
 
     run_docker_wrapper(tmp_path, input_file)
 

--- a/vantage6/tools/deserialization.py
+++ b/vantage6/tools/deserialization.py
@@ -12,7 +12,7 @@ def deserialize(file, data_format):
     :return:
     """
     try:
-        return _deserializers[data_format](file)
+        return _deserializers[data_format.lower()](file)
     except KeyError as e:
         raise Exception(f'Deserialization of {data_format} has not been implemented.')
 

--- a/vantage6/tools/deserialization.py
+++ b/vantage6/tools/deserialization.py
@@ -1,0 +1,45 @@
+import json
+import pickle
+
+_deserializers = {}
+
+
+def deserialize(file, data_format):
+    """
+    Lookup data_format in deserializer mapping and return the associated
+    :param file:
+    :param data_format:
+    :return:
+    """
+    try:
+        return _deserializers[data_format](file)
+    except KeyError as e:
+        raise Exception(f'Deserialization of {data_format} has not been implemented.')
+
+
+def deserializer(data_format):
+    """
+    Register function as deserializer by adding it to the `_deserializers` map with key `data_format`.
+
+    :param data_format:
+    :return:
+    """
+
+    def decorator_deserializer(func):
+        # Register deserialization function
+        _deserializers[data_format] = func
+
+        # Return function without modifications so it can also be run without retrieving it from `_deserializers`.
+        return func
+
+    return decorator_deserializer
+
+
+@deserializer('json')
+def deserialize_json(file):
+    return json.load(file)
+
+
+@deserializer('pickle')
+def deserialize_pickle(file):
+    return pickle.load(file)

--- a/vantage6/tools/docker_wrapper.py
+++ b/vantage6/tools/docker_wrapper.py
@@ -1,7 +1,6 @@
 import os
-import json
-import csv
 import pickle
+
 import pandas
 
 from vantage6.tools.dispatch_rpc import dispact_rpc
@@ -30,7 +29,6 @@ def docker_wrapper(module: str):
     info(f"Using '{data_file}' as database")
     # with open(data_file, "r") as fp:
     data = pandas.read_csv(data_file)
-        # data = csv.reader(fp)
 
     # make the actual call to the method/function
     info("Dispatching ...")
@@ -46,7 +44,6 @@ def docker_wrapper(module: str):
 
 def _read_formatted(file):
     data_format = _read_data_format(file)
-
 
 
 def _read_data_format(file):

--- a/vantage6/tools/docker_wrapper.py
+++ b/vantage6/tools/docker_wrapper.py
@@ -42,3 +42,40 @@ def docker_wrapper(module: str):
     info(f"Writing output to {output_file}")
     with open(output_file, 'wb') as fp:
         fp.write(pickle.dumps(output))
+
+
+def _read_formatted(file):
+    data_format = _read_data_format(file)
+
+
+
+def _read_data_format(file):
+    """
+    Try to read the prescribed data format. The data format should be specified as follows: DATA_FORMAT.ACTUAL_BYTES.
+    This function will attempt to read the string before the period. It will fail if the file is not in the right
+    format.
+
+    :param file: Input file received from vantage infrastructure.
+    :return:
+    """
+
+    while True:
+        char = file.read(1).decode()
+
+        if char == '.':
+            break
+        else:
+            yield char
+
+    # The file didn't have a format prepended
+    raise ValueError
+
+
+def load_data(input_file):
+    with open(input_file, "rb") as fp:
+        try:
+            input_data = read_formatted(fp)
+        except:
+            fp.read()
+            input_data = pickle.load(fp)
+    return input_data

--- a/vantage6/tools/exceptions.py
+++ b/vantage6/tools/exceptions.py
@@ -1,0 +1,2 @@
+class DeserializationException(Exception):
+    pass


### PR DESCRIPTION
Implemented custom deserialization in python docker wrapper.

When the input is sent by the client in the old way it will still be parsed as a pickle, but now it is also possible to send input as json.
The input string should look as follows before it is base64 encoded and sent to the server:
`json.{"key": "etc.."}`

New deserializers can easily be implemented by creating a new function in `vantage6/tools/deserialization.py` with `deserializer('DATA_FORMAT')`